### PR TITLE
Bug Fix: Corrected Date Issue at Beginning of Month

### DIFF
--- a/board/models.py
+++ b/board/models.py
@@ -50,9 +50,9 @@ class Service(models.Model):
         events = self.events.select_related().filter(start__gt=ago, start__lt=date.today())
         
         stats = {}
-        
-        for i in range(5):
-            stats[yesterday.day] = {
+
+        while yesterday > ago:
+            stats["%s-%s" % (yesterday.month,yesterday.day)] = {
                 "image": lowest.image,
                 "day": yesterday,
             }
@@ -72,8 +72,8 @@ class Service(models.Model):
 
         for k in keys:
             results.append(stats[k])
-            
-        return results
+
+        return results        
     
     def current_event(self):
         try:


### PR DESCRIPTION
Whenever months rolled over dates would not align properly. As a result, you would see correct headers but incorrect data links at the bottom. Handled comparison with Month AND Day.

Example Prior:
HEADER    Current  |  03 | 02 | 01 | 30 | 29
LINKS        Current  |  30 | 29 | 03 | 02 | 01

New Corrected:
HEADER    Current  |     03   |    02    |    01    |    30    |    29
LINKS        Current  |  (07)03 | (07)02 |  (07)01 | (06)30 | (06)29

The month is invisible to user on frontend but backend processing it is used.
