### PR TITLE
Fixed Overall Reporting

### DIFF
--- a/board/models.py
+++ b/board/models.py
@@ -38,16 +38,15 @@ class Service(models.Model):
         return 'service', [self.slug]
 
     def last_known_event(self, event_date, counter=0):
-	print event_date
         temp = Event.objects.filter(service=self, start__year=event_date.year, start__month=event_date.month, start__day=event_date.day)
-	if temp:
-  	   temp = temp.order_by('id')[0]
+        if temp:
+            temp = temp.order_by('id')[0]
         else:
-           counter += counter + 1
-           if counter > 31:
-               temp = None
-           else:
-               temp = self.last_known_event(event_date - timedelta(days=1), counter)
+            counter += counter + 1
+            if counter > 31:
+                temp = None
+            else:
+                temp = self.last_known_event(event_date - timedelta(days=1), counter)
         return temp
 
     def last_five_days(self):
@@ -65,9 +64,9 @@ class Service(models.Model):
 
         while yesterday > ago:
             temp = self.last_known_event(yesterday)
-	    if temp:
-	        image = temp.status.image
-	    else:
+            if temp:
+                image = temp.status.image
+            else:
                 image = lowest.image
             stats["%s-%s" % (yesterday.month,yesterday.day)] = {
                 "image": image,

--- a/board/models.py
+++ b/board/models.py
@@ -40,7 +40,7 @@ class Service(models.Model):
     def last_known_event(self, event_date, counter=0):
         temp = Event.objects.filter(service=self, start__year=event_date.year, start__month=event_date.month, start__day=event_date.day)
         if temp:
-            temp = temp.order_by('id')[0]
+            temp = temp.order_by('-id')[0]
         else:
             counter += counter + 1
             if counter > 31:


### PR DESCRIPTION
I recently fixed an issue, which was reported by a user, about false reporting of events. For example. If there was an issue that occurred on any day in the past five days, it would automatically display as OK, which is not always the case.

I added a model function to get the last_known_event. This function checks to see if there is a event posted for the current day, if so it just returns the last posted event (by id). If there is no event, however, it will check the previous day from the date passed. This last piece is recursive, meaning it will check each previous day from a previous day until it matches a last known event. To prevent a issue with recursive depth, I have added the case that if the amount of times the function is called is greater than 31 (31 days), determine that everything is running as intended. 

As we intend our users to have a check at least once a month, I am not expecting the last piece to be an issue, especially since they will create an "OK" event. Otherwise, this application can get really bogged down with performance issues.
